### PR TITLE
add cmux configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ This is a dotfiles repository that serves as a Single Source of Truth (SSOT) for
 
 ```
 settings/
+├── cmux/          # cmux terminal multiplexer configuration (Ghostty config format)
+│   └── config.ghostty
 ├── rectangle/     # Rectangle window manager configuration
 │   └── RectangleConfig.json
 ├── zed/           # Zed editor configuration
@@ -40,9 +42,15 @@ The init script is designed to be **idempotent** - it checks if tools are alread
 
 ### Configuration File Paths
 When updating the init script, ensure config files are downloaded to:
+- cmux: `~/Library/Application Support/com.mitchellh.ghostty/config.ghostty`
 - Rectangle: `~/Library/Application Support/Rectangle/` (auto-loaded on launch, file is renamed after loading)
 - Zed: `~/.config/zed/`
 - Zsh: `~/.zshrc`
+
+### cmux Configuration
+- Uses Ghostty config format (`config.ghostty`)
+- Font: Monaspace Krypton (matching Zed), Korean fallback: Sarasa Term K
+- Font style: Bold
 
 ### Zed Editor Configuration
 - Uses TypeScript language servers: `tsgo` and `vtsls`

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -114,4 +114,8 @@ echo "Updating rectangle config..."
 mkdir -p ~/Library/Application\ Support/Rectangle
 curl -fsSL "$BASE_URL/rectangle/RectangleConfig.json" > ~/Library/Application\ Support/Rectangle/RectangleConfig.json
 
+echo "Updating cmux config..."
+mkdir -p ~/Library/Application\ Support/com.mitchellh.ghostty
+curl -fsSL "$BASE_URL/cmux/config.ghostty" > ~/Library/Application\ Support/com.mitchellh.ghostty/config.ghostty
+
 echo "✅ Setup complete! Run 'source ~/.zshrc' to apply changes or restart your terminal."

--- a/settings/cmux/config.ghostty
+++ b/settings/cmux/config.ghostty
@@ -1,0 +1,4 @@
+font-family = Monaspace Krypton
+font-family = Sarasa Term K
+font-size = 16
+font-style = Bold


### PR DESCRIPTION
## Summary
- cmux (Ghostty config format) 설정 파일 추가
- Font: Monaspace Krypton + Korean fallback Sarasa Term K
- init.sh에 cmux config 배포 추가
- CLAUDE.md 업데이트

## Test plan
- [ ] cmux 재시작 후 영어/한글 폰트 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)